### PR TITLE
Issue 74: copy_file and backup_data_file() lax behavior 

### DIFF
--- a/src/backup.c
+++ b/src/backup.c
@@ -2466,7 +2466,8 @@ backup_files(void *arg)
 									  arguments->prev_start_lsn,
 									  current.backup_mode,
 									  instance_config.compress_alg,
-									  instance_config.compress_level))
+									  instance_config.compress_level,
+									  true))
 				{
 					/* disappeared file not to be confused with 'not changed' */
 					if (file->write_size != FILE_NOT_FOUND)
@@ -2508,7 +2509,7 @@ backup_files(void *arg)
 				else
 					dst = arguments->to_root;
 				if (skip ||
-					!copy_file(FIO_DB_HOST, dst, FIO_BACKUP_HOST, file))
+					!copy_file(FIO_DB_HOST, dst, FIO_BACKUP_HOST, file, true))
 				{
 					/* disappeared file not to be confused with 'not changed' */
 					if (file->write_size != FILE_NOT_FOUND)

--- a/src/merge.c
+++ b/src/merge.c
@@ -489,7 +489,7 @@ merge_files(void *arg)
 		 * of DELTA backup we should consider n_blocks to truncate the target
 		 * backup.
 		 */
-		if (file->write_size == BYTES_INVALID && file->n_blocks == -1)
+		if (file->write_size == BYTES_INVALID && file->n_blocks == BLOCKNUM_INVALID)
 		{
 			elog(VERBOSE, "Skip merging file \"%s\", the file didn't change",
 				 file->path);
@@ -605,7 +605,8 @@ merge_files(void *arg)
 								 to_backup->start_lsn,
 								 to_backup->backup_mode,
 								 to_backup->compress_alg,
-								 to_backup->compress_level);
+								 to_backup->compress_level,
+								 false);
 
 				file->path = prev_path;
 
@@ -645,12 +646,12 @@ merge_files(void *arg)
 											 argument->from_external);
 			makeExternalDirPathByNum(to_root, argument->to_external_prefix,
 									 new_dir_num);
-			copy_file(FIO_LOCAL_HOST, to_root, FIO_LOCAL_HOST, file);
+			copy_file(FIO_LOCAL_HOST, to_root, FIO_LOCAL_HOST, file, false);
 		}
 		else if (strcmp(file->name, "pg_control") == 0)
 			copy_pgcontrol_file(argument->from_root, FIO_LOCAL_HOST, argument->to_root, FIO_LOCAL_HOST, file);
 		else
-			copy_file(FIO_LOCAL_HOST, argument->to_root, FIO_LOCAL_HOST, file);
+			copy_file(FIO_LOCAL_HOST, argument->to_root, FIO_LOCAL_HOST, file, false);
 
 		/*
 		 * We need to save compression algorithm type of the target backup to be

--- a/src/pg_probackup.h
+++ b/src/pg_probackup.h
@@ -629,13 +629,14 @@ extern bool backup_data_file(backup_files_arg* arguments,
 							 const char *to_path, pgFile *file,
 							 XLogRecPtr prev_backup_start_lsn,
 							 BackupMode backup_mode,
-							 CompressAlg calg, int clevel);
+							 CompressAlg calg, int clevel,
+							 bool missing_ok);
 extern void restore_data_file(const char *to_path,
 							  pgFile *file, bool allow_truncate,
 							  bool write_header,
 							  uint32 backup_version);
 extern bool copy_file(fio_location from_location, const char *to_root,
-					  fio_location to_location, pgFile *file);
+					  fio_location to_location, pgFile *file, bool missing_ok);
 
 extern bool check_file_pages(pgFile *file, XLogRecPtr stop_lsn,
 							 uint32 checksum_version, uint32 backup_version);

--- a/src/restore.c
+++ b/src/restore.c
@@ -742,7 +742,7 @@ restore_files(void *arg)
 			if (backup_contains_external(external_path,
 										 arguments->dest_external_dirs))
 				copy_file(FIO_BACKUP_HOST,
-						  external_path, FIO_DB_HOST, file);
+						  external_path, FIO_DB_HOST, file, false);
 		}
 		else if (strcmp(file->name, "pg_control") == 0)
 			copy_pgcontrol_file(from_root, FIO_BACKUP_HOST,
@@ -751,7 +751,7 @@ restore_files(void *arg)
 		else
 			copy_file(FIO_BACKUP_HOST,
 					  instance_config.pgdata, FIO_DB_HOST,
-					  file);
+					  file, false);
 
 		/* print size of restored file */
 		if (file->write_size != BYTES_INVALID)


### PR DESCRIPTION
copy_file and backup_data_file() always treat missing source file as non-error condition.
Added missing_ok flag to remedy that.