### PR TITLE
[PGPRO-5387] Vanilla fixed idle replica archiving

### DIFF
--- a/tests/backup.py
+++ b/tests/backup.py
@@ -2351,47 +2351,45 @@ class BackupTest(ProbackupTest, unittest.TestCase):
 
         replica.slow_start(replica=True)
 
-        # Archive backups from replica in this test are disabled,
-        # because WAL archiving on replica in idle DB in PostgreSQL is broken:
-        # replica will not archive the previous WAL until it receives new records in the next WAL file,
-        # this "lazy" archiving can be seen in src/backend/replication/walreceiver.c:XLogWalRcvWrite()
-        # (see !XLByteInSeg checking and XLogArchiveNotify() calling).
-        #
         # self.switch_wal_segment(node)
-        #self.backup_node(
-        #    backup_dir, 'replica', replica,
-        #    datname='backupdb', options=['-U', 'backup'])
+        # self.switch_wal_segment(node)
+
+        self.backup_node(
+            backup_dir, 'replica', replica,
+            datname='backupdb', options=['-U', 'backup'])
 
         # stream full backup from replica
         self.backup_node(
             backup_dir, 'replica', replica,
             datname='backupdb', options=['--stream', '-U', 'backup'])
 
+#        self.switch_wal_segment(node)
+
         # PAGE backup from replica
-        #self.switch_wal_segment(node)
-        #self.backup_node(
-        #    backup_dir, 'replica', replica, backup_type='page',
-        #    datname='backupdb', options=['-U', 'backup', '--archive-timeout=30s'])
+        self.switch_wal_segment(node)
+        self.backup_node(
+            backup_dir, 'replica', replica, backup_type='page',
+            datname='backupdb', options=['-U', 'backup', '--archive-timeout=30s'])
 
         self.backup_node(
             backup_dir, 'replica', replica, backup_type='page',
             datname='backupdb', options=['--stream', '-U', 'backup'])
 
         # DELTA backup from replica
-        #self.switch_wal_segment(node)
-        #self.backup_node(
-        #    backup_dir, 'replica', replica, backup_type='delta',
-        #    datname='backupdb', options=['-U', 'backup'])
+        self.switch_wal_segment(node)
+        self.backup_node(
+            backup_dir, 'replica', replica, backup_type='delta',
+            datname='backupdb', options=['-U', 'backup'])
         self.backup_node(
             backup_dir, 'replica', replica, backup_type='delta',
             datname='backupdb', options=['--stream', '-U', 'backup'])
 
         # PTRACK backup from replica
         if self.ptrack:
-            #self.switch_wal_segment(node)
-            #self.backup_node(
-            #    backup_dir, 'replica', replica, backup_type='ptrack',
-            #    datname='backupdb', options=['-U', 'backup'])
+            self.switch_wal_segment(node)
+            self.backup_node(
+                backup_dir, 'replica', replica, backup_type='ptrack',
+                datname='backupdb', options=['-U', 'backup'])
             self.backup_node(
                 backup_dir, 'replica', replica, backup_type='ptrack',
                 datname='backupdb', options=['--stream', '-U', 'backup'])

--- a/tests/replica.py
+++ b/tests/replica.py
@@ -291,16 +291,6 @@ class ReplicaTest(ProbackupTest, unittest.TestCase):
 
         self.wait_until_replica_catch_with_master(master, replica)
 
-        master.pgbench_init(scale=5)
-        # Continuous making some changes on master,
-        # because WAL archiving on replica in idle DB in PostgreSQL is broken:
-        # replica will not archive the previous WAL until it receives new records in the next WAL file,
-        # this "lazy" archiving can be seen in src/backend/replication/walreceiver.c:XLogWalRcvWrite()
-        # (see !XLByteInSeg checking and XLogArchiveNotify() calling).
-        pgbench = master.pgbench(
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            options=['-T', '3', '-c', '1', '--no-vacuum'])
-
         backup_id = self.backup_node(
             backup_dir, 'replica', replica,
             options=[
@@ -308,9 +298,6 @@ class ReplicaTest(ProbackupTest, unittest.TestCase):
                 '--master-host=localhost',
                 '--master-db=postgres',
                 '--master-port={0}'.format(master.port)])
-
-        pgbench.wait()
-        pgbench.stdout.close()
 
         self.validate_pb(backup_dir, 'replica')
         self.assertEqual(
@@ -334,6 +321,8 @@ class ReplicaTest(ProbackupTest, unittest.TestCase):
         # Change data on master, make PAGE backup from replica,
         # restore taken backup and check that restored data equal
         # to original data
+        master.pgbench_init(scale=5)
+
         pgbench = master.pgbench(
             options=['-T', '30', '-c', '2', '--no-vacuum'])
 


### PR DESCRIPTION
See https://www.postgresql.org/message-id/flat/20210901.121225.1339494423357751537.horikyota.ntt%40gmail.com#ba576416b65f28725488861280805e84

So we can revert two workarounds:
* Revert "[PGPRO-5378] fix unstable tests.replica.ReplicaTest.test_replica_archive_page_backup"
This reverts commit 90b9b5745e19909a6f5f28761def49ef6bfef0e4.
* Revert ""fix" unstable backup.BackupTest.test_backup_with_less_privileges_role (disable tests in archive mode from replica)"
This reverts commit 5dcd1ce2b817219180005b1b70a231798cd96ec5.