### PR TITLE
PBCKP-145: added check of unlogged table is restored as empty table

### DIFF
--- a/tests/exclude.py
+++ b/tests/exclude.py
@@ -343,7 +343,6 @@ class ExcludeTest(ProbackupTest, unittest.TestCase):
 
         show_pb_page = self.show_pb(
             backup_dir, 'node', backup_id=backup_id_page)
-        show_archive = self.show_archive(backup_dir, 'node')
         self.assertTrue(show_pb_page["data-bytes"] < 1024*1024)
 
         # Clean after yourself

--- a/tests/exclude.py
+++ b/tests/exclude.py
@@ -276,7 +276,6 @@ class ExcludeTest(ProbackupTest, unittest.TestCase):
             self.assertEqual(
                 node.execute(
                     'postgres',
-                    # TODO REVIEW unfortunately this make auto conversion from string to int, it's weird for me
                     'select count(*) from test')[0][0],
                 0)
 

--- a/tests/exclude.py
+++ b/tests/exclude.py
@@ -235,9 +235,9 @@ class ExcludeTest(ProbackupTest, unittest.TestCase):
                     'postgres',
                     'insert into test select generate_series(0,20050000)::text')
 
-            rel_path = node.safe_psql(
+            rel_path = node.execute(
                 'postgres',
-                "select pg_relation_filepath('test')").decode('utf-8').rstrip()
+                "select pg_relation_filepath('test')")[0][0]
 
             backup_id = self.backup_node(
                 backup_dir, 'node', node,
@@ -274,10 +274,11 @@ class ExcludeTest(ProbackupTest, unittest.TestCase):
             node.slow_start()
 
             self.assertEqual(
-                node.safe_psql(
+                node.execute(
                     'postgres',
-                    'select count(*) from test').decode('utf-8').rstrip(),
-                '0')
+                    # TODO REVIEW unfortunately this make auto conversion from string to int, it's weird for me
+                    'select count(*) from test')[0][0],
+                0)
 
         # Clean after yourself
         self.del_test_dir(module_name, fname)

--- a/tests/exclude.py
+++ b/tests/exclude.py
@@ -203,8 +203,10 @@ class ExcludeTest(ProbackupTest, unittest.TestCase):
     # @unittest.skip("skip")
     def test_exclude_unlogged_tables_2(self):
         """
-        make node, create unlogged, take FULL, check
-        that unlogged was not backed up
+        1. make node, create unlogged, take FULL, DELTA, PAGE,
+            check that unlogged table files was not backed up
+        2. restore FULL, DELTA, PAGE to empty db,
+            ensure unlogged table exist and is epmty
         """
         fname = self.id().split('.')[3]
         backup_dir = os.path.join(self.tmp_path, module_name, fname, 'backup')
@@ -219,6 +221,8 @@ class ExcludeTest(ProbackupTest, unittest.TestCase):
         self.add_instance(backup_dir, 'node', node)
         self.set_archiving(backup_dir, 'node', node)
         node.slow_start()
+
+        backup_ids = []
 
         for backup_type in ['full', 'delta', 'page']:
 
@@ -239,6 +243,8 @@ class ExcludeTest(ProbackupTest, unittest.TestCase):
                 backup_dir, 'node', node,
                 backup_type=backup_type, options=['--stream'])
 
+            backup_ids.append(backup_id)
+
             filelist = self.get_backup_filelist(
                 backup_dir, 'node', backup_id)
 
@@ -258,95 +264,24 @@ class ExcludeTest(ProbackupTest, unittest.TestCase):
                 rel_path + '.3', filelist,
                 "Unlogged table was not excluded")
 
-        # Clean after yourself
-        self.del_test_dir(module_name, fname)
+        # ensure restoring retrieves back only empty unlogged table
+        for backup_id in backup_ids:
+            node.stop()
+            node.cleanup()
 
-    # @unittest.skip("skip")
-    #TODO REVIEW time consuming test, but not more than 25 secs and 850M disk space :(
-    def test_exclude_unlogged_table_and_check_backup_size_unchanged(self):
-        """
-        - make backup on empty db, capture full backup stats
-        - fill unlogged table by 160M, capture "full" backup, check its size is almost the same as for empty one
-        - increase unlogged table by 160M again, check "delta" backup size increment is less than 1M
-        - increase unlogged table by 160M again, check "page" backup size increment is less than 1M
-        """
+            self.restore_node(backup_dir, 'node', node, backup_id=backup_id)
 
-        fname = self.id().split('.')[3]
-        backup_dir = os.path.join(self.tmp_path, module_name, fname, 'backup')
-        node = self.make_simple_node(
-            base_dir=os.path.join(module_name, fname, 'node'),
-            set_replication=True,
-            initdb_params=['--data-checksums'],
-            pg_options={
-                "shared_buffers": "10MB"})
+            node.slow_start()
 
-        self.init_pb(backup_dir)
-        self.add_instance(backup_dir, 'node', node)
-        self.set_archiving(backup_dir, 'node', node)
-        node.slow_start()
-
-        # init full backup and stats on empty db
-        backup_id_empty = self.backup_node(
-            backup_dir, 'node', node, backup_type="full",
-            return_id=True,
-            options=["-j", "4", "--stream"]
-        )
-
-        show_pb_empty = self.show_pb(
-            backup_dir, 'node', backup_id=backup_id_empty)  # ['recovery-time']
-
-        # fill unlogged table by 400M, ensure second "full" backup is almost the same size
-        node.safe_psql(
-            "postgres",
-            "create unlogged table t_logged as select i"
-            " as id from generate_series(0,4005000) i")
-
-        backup_id_full = self.backup_node(
-            backup_dir, 'node', node, backup_type="full",
-            return_id=True,
-            options=["-j", "4", "--stream"]
-        )
-
-        show_pb_full = self.show_pb(
-            backup_dir, 'node', backup_id=backup_id_full)
-
-        self.assertTrue(show_pb_full["data-bytes"] - show_pb_empty["data-bytes"] < 1024*1024)
-
-        # ensure "delta" backup skips 400M increment to unlogged table
-        node.safe_psql(
-            "postgres",
-            "insert into t_logged "
-            " select from generate_series(0,4005000)")
-
-        backup_id_delta = self.backup_node(
-            backup_dir, 'node', node, backup_type="delta",
-            return_id=True,
-            options=["-j", "4", "--stream"]
-        )
-
-        show_pb_delta = self.show_pb(
-            backup_dir, 'node', backup_id=backup_id_delta)
-
-        self.assertTrue(show_pb_delta["data-bytes"] < 1024*1024)
-
-        # ensure "page" backup skips 400M increment to unlogged table
-        node.safe_psql(
-            "postgres",
-            "insert into t_logged "
-            " select from generate_series(0,4005000)")
-
-        backup_id_page = self.backup_node(
-            backup_dir, 'node', node, backup_type="page",
-            return_id=True,
-            options=["-j", "4", "--stream"]
-        )
-
-        show_pb_page = self.show_pb(
-            backup_dir, 'node', backup_id=backup_id_page)
-        self.assertTrue(show_pb_page["data-bytes"] < 1024*1024)
+            self.assertEqual(
+                node.safe_psql(
+                    'postgres',
+                    'select count(*) from test').decode('utf-8').rstrip(),
+                '0')
 
         # Clean after yourself
         self.del_test_dir(module_name, fname)
+
 
     # @unittest.skip("skip")
     def test_exclude_log_dir(self):


### PR DESCRIPTION
UNLOGGED table should be restored as empty with `"select count(*) from table" == 0`. such kind of test is added 
https://github.com/postgrespro/pg_probackup/issues/360