### PR TITLE
rapid agent close + disable ssh control master.

### DIFF
--- a/src/utils/file.c
+++ b/src/utils/file.c
@@ -489,8 +489,10 @@ fio_disconnect(void)
 		Assert(hdr.cop == FIO_DISCONNECTED);
 		SYS_CHECK(close(fio_stdin));
 		SYS_CHECK(close(fio_stdout));
+		SYS_CHECK(close(fio_stderr));
 		fio_stdin = 0;
 		fio_stdout = 0;
+		fio_stderr = 0;
 		wait_ssh();
 	}
 }
@@ -3403,7 +3405,8 @@ fio_communicate(int in, int out)
 		  case FIO_DISCONNECT:
 			hdr.cop = FIO_DISCONNECTED;
 			IO_CHECK(fio_write_all(out, &hdr, sizeof(hdr)), sizeof(hdr));
-			break;
+			free(buf);
+			return;
 		  case FIO_GET_ASYNC_ERROR:
 			fio_get_async_error_impl(out);
 			break;

--- a/src/utils/remote.c
+++ b/src/utils/remote.c
@@ -148,6 +148,9 @@ bool launch_agent(void)
 	ssh_argv[ssh_argc++] = "Compression=no";
 
 	ssh_argv[ssh_argc++] = "-o";
+	ssh_argv[ssh_argc++] = "ControlMaster=no";
+
+	ssh_argv[ssh_argc++] = "-o";
 	ssh_argv[ssh_argc++] = "LogLevel=error";
 
 	ssh_argv[ssh_argc++] = instance_config.remote.host;


### PR DESCRIPTION
ControlMaster=yes or ControlMaster=auto in ~/.ssh/config could lead to ssh client stall. Override this setting.

Also, make fast agent exit on FIO_DISCONNECT .
And close fio_stderr in fio_disconnect.