### PR TITLE
Repair backup failed (the value of segment_size is greater than 2G)

### DIFF
--- a/src/catalog.c
+++ b/src/catalog.c
@@ -1117,7 +1117,7 @@ get_backup_filelist(pgBackup *backup, bool strict)
 			file->segno = (int) segno;
 
 		if (get_control_value_int64(buf, "n_blocks", &n_blocks, false))
-			file->n_blocks = (int) n_blocks;
+			file->n_blocks = (int64) n_blocks;
 
 		if (get_control_value_int64(buf, "n_headers", &n_headers, false))
 			file->n_headers = (int) n_headers;
@@ -2568,7 +2568,7 @@ write_backup_filelist(pgBackup *backup, parray *files, const char *root,
 			len += sprintf(line+len, ",\"linked\":\"%s\"", file->linked);
 
 		if (file->n_blocks > 0)
-			len += sprintf(line+len, ",\"n_blocks\":\"%i\"", file->n_blocks);
+			len += sprintf(line+len, ",\"n_blocks\":\"%ld\"", file->n_blocks);
 
 		if (file->n_headers > 0)
 		{

--- a/src/pg_probackup.h
+++ b/src/pg_probackup.h
@@ -267,7 +267,7 @@ typedef struct pgFile
 	Oid		relOid;			/* relOid extracted from path, if applicable */
 	ForkName   forkName;	/* forkName extracted from path, if applicable */
 	int		segno;			/* Segment number for ptrack */
-	int		n_blocks;		/* number of blocks in the data file in data directory */
+	int64		n_blocks;		/* number of blocks in the data file in data directory */
 	bool	is_cfs;			/* Flag to distinguish files compressed by CFS*/
 	int		external_dir_num;	/* Number of external directory. 0 if not external */
 	bool	exists_in_prev;		/* Mark files, both data and regular, that exists in previous backup */
@@ -677,8 +677,8 @@ typedef struct BackupPageHeader
 typedef struct BackupPageHeader2
 {
 	XLogRecPtr  lsn;
-	int32	    block;			 /* block number */
-	int32       pos;             /* position in backup file */
+	int64	    block;			 /* block number */
+	int64       pos;             /* position in backup file */
 	uint16      checksum;
 } BackupPageHeader2;
 
@@ -1115,9 +1115,9 @@ extern bool create_empty_file(fio_location from_location, const char *to_root,
 							  fio_location to_location, pgFile *file);
 
 extern PageState *get_checksum_map(const char *fullpath, uint32 checksum_version,
-								int n_blocks, XLogRecPtr dest_stop_lsn, BlockNumber segmentno);
+								int64 n_blocks, XLogRecPtr dest_stop_lsn, BlockNumber segmentno);
 extern datapagemap_t *get_lsn_map(const char *fullpath, uint32 checksum_version,
-								  int n_blocks, XLogRecPtr shift_lsn, BlockNumber segmentno);
+								  int64 n_blocks, XLogRecPtr shift_lsn, BlockNumber segmentno);
 extern bool validate_file_pages(pgFile *file, const char *fullpath, XLogRecPtr stop_lsn,
 							    uint32 checksum_version, uint32 backup_version, HeaderMap *hdr_map);
 

--- a/src/utils/file.c
+++ b/src/utils/file.c
@@ -2138,7 +2138,7 @@ fio_copy_pages(const char *to_fullpath, const char *from_fullpath, pgFile *file,
 
 			COMP_FILE_CRC32(true, file->crc, buf, hdr.size);
 
-			if (fio_fseek(out, blknum * BLCKSZ) < 0)
+			if (fio_fseek(out, ((int64)blknum) * BLCKSZ) < 0)
 			{
 				elog(ERROR, "Cannot seek block %u of \"%s\": %s",
 					blknum, to_fullpath, strerror(errno));
@@ -2196,7 +2196,7 @@ fio_send_pages_impl(int out, char* buf)
 	datapagemap_iterator_t *iter = NULL;
 	/* page headers */
 	int32       hdr_num = -1;
-	int32       cur_pos_out = 0;
+	int64       cur_pos_out = 0;
 	BackupPageHeader2 *headers = NULL;
 
 	/* open source file */


### PR DESCRIPTION
If the value of segment_size is greater than 2G, the file length will overflow. In this case, the backup will fail.