### PR TITLE
[PGPRO-6676]: correction of the warning

### DIFF
--- a/src/pg_probackup.h
+++ b/src/pg_probackup.h
@@ -50,12 +50,6 @@
 #include <pthread.h>
 #endif
 
-#if PG_VERSION_NUM >= 150000
-// _() is explicitly undefined in libpq-int.h
-// https://github.com/postgres/postgres/commit/28ec316787674dd74d00b296724a009b6edc2fb0
-#define _(s) gettext(s)
-#endif
-
 /* Wrap the code that we're going to delete after refactoring in this define*/
 #define REFACTORE_ME
 


### PR DESCRIPTION
  src/pg_probackup.h:56: warning: "_" redefined
   56 | #define _(s) gettext(s)
  ../../src/include/c.h:1233: note: this is the
            location of the previous definition
   1233 | #define _(x) gettext(x)