### PR TITLE
Respect PATH in a  pg_probackup binary check

### DIFF
--- a/tests/helpers/ptrack_helpers.py
+++ b/tests/helpers/ptrack_helpers.py
@@ -242,10 +242,7 @@ class ProbackupTest(object):
         self.user = self.get_username()
         self.probackup_path = None
         if 'PGPROBACKUPBIN' in self.test_env:
-            if (
-                os.path.isfile(self.test_env["PGPROBACKUPBIN"]) and
-                os.access(self.test_env["PGPROBACKUPBIN"], os.X_OK)
-            ):
+            if shutil.which(self.test_env["PGPROBACKUPBIN"]):
                 self.probackup_path = self.test_env["PGPROBACKUPBIN"]
             else:
                 if self.verbose:


### PR DESCRIPTION
This modification allows one to set PGPROBACKUPBIN to a binary included in PATH.