### PR TITLE
rework file stat handling to simplify and cross-platform-ability

### DIFF
--- a/src/archive.c
+++ b/src/archive.c
@@ -390,7 +390,7 @@ push_file_internal(const char *wal_file_name, const char *pg_xlog_dir,
 /* partial handling */
     pio_stat_t st;
     int partial_try_count = 0;
-    ssize_t partial_file_size = 0;
+    int64_t partial_file_size = 0;
     bool partial_is_stale = true;
     size_t len;
     err_i err = $noerr();

--- a/src/archive.c
+++ b/src/archive.c
@@ -388,7 +388,7 @@ push_file_internal(const char *wal_file_name, const char *pg_xlog_dir,
     char to_fullpath[MAXPGPATH];
     char to_fullpath_part[MAXPGPATH];
 /* partial handling */
-    struct stat st;
+    pio_stat_t st;
     int partial_try_count = 0;
     ssize_t partial_file_size = 0;
     bool partial_is_stale = true;
@@ -466,11 +466,11 @@ push_file_internal(const char *wal_file_name, const char *pg_xlog_dir,
             elog(LOG,
                  "Temp WAL file already exists, waiting on it %u seconds: \"%s\"",
                  archive_timeout, to_fullpath_part);
-            partial_file_size = st.st_size;
+            partial_file_size = st.pst_size;
         }
 
         /* file size is changing */
-        if (st.st_size != partial_file_size)
+        if (st.pst_size != partial_file_size)
             partial_is_stale = false;
 
         sleep(1);

--- a/src/catchup.c
+++ b/src/catchup.c
@@ -439,7 +439,7 @@ catchup_thread_runner(void *arg)
 
 		if (file->write_size == BYTES_INVALID)
 		{
-			elog(LOG, "Skipping the unchanged file: \"%s\", read %zu bytes", from_fullpath, file->read_size);
+			elog(LOG, "Skipping the unchanged file: \"%s\", read %lld bytes", from_fullpath, (long long)file->read_size);
 			continue;
 		}
 
@@ -630,8 +630,8 @@ do_catchup(const char *source_pgdata, const char *dest_pgdata, int num_threads, 
 
 	/* for fancy reporting */
 	time_t		start_time, end_time;
-	ssize_t		transfered_datafiles_bytes = 0;
-	ssize_t		transfered_walfiles_bytes = 0;
+	int64_t		transfered_datafiles_bytes = 0;
+	int64_t		transfered_walfiles_bytes = 0;
 	char		pretty_source_bytes[20];
 	err_i		err = $noerr();
 

--- a/src/checkdb.c
+++ b/src/checkdb.c
@@ -147,7 +147,7 @@ check_files(void *arg)
 			elog(ERROR, "interrupted during checkdb");
 
 		/* No need to check directories */
-		if (S_ISDIR(file->mode))
+		if (file->kind == PIO_KIND_DIRECTORY)
 			continue;
 
 		if (!pg_atomic_test_set_flag(&file->lock))
@@ -161,7 +161,7 @@ check_files(void *arg)
 			elog(INFO, "Progress: (%d/%d). Process file \"%s\"",
 				 i + 1, n_files_list, from_fullpath);
 
-		if (S_ISREG(file->mode))
+		if (file->kind == PIO_KIND_REGULAR)
 		{
 			/* check only uncompressed by cfs datafiles */
 			if (file->is_datafile && !file->is_cfs)

--- a/src/delete.c
+++ b/src/delete.c
@@ -794,8 +794,8 @@ delete_walfiles_in_tli(InstanceState *instanceState, XLogRecPtr keep_lsn, timeli
 	char 		first_to_del_str[MAXFNAMELEN];
 	char 		oldest_to_keep_str[MAXFNAMELEN];
 	int			i;
-	size_t		wal_size_logical = 0;
-	size_t		wal_size_actual = 0;
+	int64_t		wal_size_logical = 0;
+	int64_t		wal_size_actual = 0;
 	char		wal_pretty_size[20];
 	bool		purge_all = false;
 
@@ -837,7 +837,7 @@ delete_walfiles_in_tli(InstanceState *instanceState, XLogRecPtr keep_lsn, timeli
 	/* sanity */
 	if (OldestToKeepSegNo > FirstToDeleteSegNo)
 	{
-		wal_size_logical = (OldestToKeepSegNo - FirstToDeleteSegNo) * xlog_seg_size;
+		wal_size_logical = (int64_t)(OldestToKeepSegNo - FirstToDeleteSegNo) * xlog_seg_size;
 
 		/* In case of 'purge all' scenario OldestToKeepSegNo will be deleted too */
 		if (purge_all)

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -54,7 +54,7 @@ slurpFile(fio_location location, const char *datadir, const char *path, size_t *
 			ft_logerr(FT_FATAL, $errmsg(err), "slurpFile");
 	}
 
-	if (statbuf.pst_size > SIZE_MAX)
+	if (statbuf.pst_size > SSIZE_MAX)
 		ft_log(FT_FATAL, "file \"%s\" is too large: %lld",
 			   fullpath, (long long)statbuf.pst_size);
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -639,7 +639,7 @@ merge_chain(InstanceState *instanceState,
 		pgFile	   *file = (pgFile *) parray_get(dest_backup->files, i);
 
 		/* if the entry was an external directory, create it in the backup */
-		if (file->external_dir_num && S_ISDIR(file->mode))
+		if (file->external_dir_num && file->kind == PIO_KIND_DIRECTORY)
 		{
 			char		dirpath[MAXPGPATH];
 			char		new_container[MAXPGPATH];
@@ -955,6 +955,7 @@ merge_files(void *arg)
 			continue;
 
 		tmp_file = pgFileInit(dest_file->rel_path);
+		tmp_file->kind = dest_file->kind;
 		tmp_file->mode = dest_file->mode;
 		tmp_file->is_datafile = dest_file->is_datafile;
 		tmp_file->is_cfs = dest_file->is_cfs;
@@ -962,7 +963,7 @@ merge_files(void *arg)
 		tmp_file->dbOid = dest_file->dbOid;
 
 		/* Directories were created before */
-		if (S_ISDIR(dest_file->mode))
+		if (dest_file->kind == PIO_KIND_DIRECTORY)
 			goto done;
 
 		elog(progress ? INFO : LOG, "Progress: (%d/%zu). Merging file \"%s\"",

--- a/src/pg_probackup.h
+++ b/src/pg_probackup.h
@@ -211,18 +211,21 @@ typedef enum ForkName
 typedef struct pgFile
 {
 	char   *name;			/* file or directory name */
-	mode_t	mode;			/* protection (file type and permission) */
-	size_t	size;			/* size of the file */
-	time_t  mtime;			/* file st_mtime attribute, can be used only
-								during backup */
-	size_t	read_size;		/* size of the portion read (if only some pages are
+
+	pio_file_kind_e	kind;	/* kind of file */
+	uint32_t	mode;		/* protection (permission) */
+	uint64_t	size;		/* size of the file */
+
+	uint64_t	read_size;		/* size of the portion read (if only some pages are
 							   backed up, it's different from size) */
-	int64	write_size;		/* size of the backed-up file. BYTES_INVALID means
+	int64_t	write_size;		/* size of the backed-up file. BYTES_INVALID means
 							   that the file existed but was not backed up
 							   because not modified since last backup. */
-	size_t	uncompressed_size;	/* size of the backed-up file before compression
+	uint64_t	uncompressed_size;	/* size of the backed-up file before compression
 								 * and adding block headers.
 								 */
+	time_t  mtime;			/* file st_mtime attribute, can be used only
+								during backup */
 							/* we need int64 here to store '-1' value */
 	pg_crc32 crc;			/* CRC value of the file, regular file only */
 	char   *rel_path;		/* relative path of the file */
@@ -1022,7 +1025,6 @@ extern bool backup_contains_external(const char *dir, parray *dirs_list);
 extern bool dir_is_empty(const char *path, fio_location location);
 
 extern bool fileExists(const char *path, fio_location location);
-extern size_t pgFileSize(const char *path);
 
 extern pgFile *pgFileNew(const char *path, const char *rel_path,
 						 bool follow_symlink, int external_dir_num,

--- a/src/pg_probackup.h
+++ b/src/pg_probackup.h
@@ -214,14 +214,14 @@ typedef struct pgFile
 
 	pio_file_kind_e	kind;	/* kind of file */
 	uint32_t	mode;		/* protection (permission) */
-	uint64_t	size;		/* size of the file */
+	int64_t	size;		/* size of the file */
 
-	uint64_t	read_size;		/* size of the portion read (if only some pages are
+	int64_t	read_size;		/* size of the portion read (if only some pages are
 							   backed up, it's different from size) */
 	int64_t	write_size;		/* size of the backed-up file. BYTES_INVALID means
 							   that the file existed but was not backed up
 							   because not modified since last backup. */
-	uint64_t	uncompressed_size;	/* size of the backed-up file before compression
+	int64_t	uncompressed_size;	/* size of the backed-up file before compression
 								 * and adding block headers.
 								 */
 	time_t  mtime;			/* file st_mtime attribute, can be used only
@@ -593,7 +593,7 @@ struct timelineInfo {
 	XLogSegNo end_segno;	/* last present segment in this timeline */
 	size_t	n_xlog_files;	/* number of segments (only really existing)
 							 * does not include lost segments */
-	size_t	size;			/* space on disk taken by regular WAL files */
+	int64_t	size;			/* space on disk taken by regular WAL files */
 	parray *backups;		/* array of pgBackup sturctures with info
 							 * about backups belonging to this timeline */
 	parray *xlog_filelist;	/* array of ordinary WAL segments, '.partial'
@@ -1055,7 +1055,7 @@ extern bool check_data_file(ConnectionArgs *arguments, pgFile *file,
 
 extern void catchup_data_file(pgFile *file, const char *from_fullpath, const char *to_fullpath,
 								 XLogRecPtr sync_lsn, BackupMode backup_mode,
-								 uint32 checksum_version, size_t prev_size);
+								 uint32 checksum_version, int64_t prev_size);
 extern void backup_data_file(pgFile *file, const char *from_fullpath, const char *to_fullpath,
 							 XLogRecPtr prev_backup_start_lsn, BackupMode backup_mode,
 							 CompressAlg calg, int clevel, uint32 checksum_version,

--- a/src/show.c
+++ b/src/show.c
@@ -1089,7 +1089,7 @@ show_archive_json(const char *instance_name, uint32 xlog_seg_size,
 		appendPQExpBuffer(buf, "%zu", tlinfo->n_xlog_files);
 
 		json_add_key(buf, "size", json_level);
-		appendPQExpBuffer(buf, "%zu", tlinfo->size);
+		appendPQExpBuffer(buf, "%lld", (long long)tlinfo->size);
 
 		json_add_key(buf, "zratio", json_level);
 

--- a/src/util.c
+++ b/src/util.c
@@ -403,9 +403,9 @@ copy_pgcontrol_file(fio_location from_location, const char *from_fullpath,
 	digestControlFile(&ControlFile, buffer, size);
 
 	file->crc = ControlFile.crc;
-	file->read_size = size;
-	file->write_size = size;
-	file->uncompressed_size = size;
+	file->read_size = (int64_t)size;
+	file->write_size = (int64_t)size;
+	file->uncompressed_size = (int64_t)size;
 
 	writeControlFile(to_location, to_fullpath, &ControlFile);
 

--- a/src/utils/file.c
+++ b/src/utils/file.c
@@ -53,7 +53,7 @@ typedef struct
 {
 	pio_file_kind_e kind;
 	mode_t  mode;
-	size_t  size;
+	int64_t size;
 	time_t  mtime;
 	bool    is_datafile;
 	Oid     tblspcOid;
@@ -1914,6 +1914,7 @@ fio_send_pages(const char *to_fullpath, const char *from_fullpath, pgFile *file,
 	}
 
 	req.arg.nblocks = file->size/BLCKSZ;
+	Assert((int64_t)req.arg.nblocks * BLCKSZ == file->size);
 	req.arg.segmentno = file->segno * RELSEG_SIZE;
 	req.arg.horizonLsn = horizonLsn;
 	req.arg.checksumVersion = checksum_version;

--- a/src/utils/file.c
+++ b/src/utils/file.c
@@ -51,6 +51,7 @@ typedef struct {
 
 typedef struct
 {
+	pio_file_kind_e kind;
 	mode_t  mode;
 	size_t  size;
 	time_t  mtime;
@@ -256,6 +257,110 @@ fio_get_agent_version(int* protocol, char* payload_buf, size_t payload_buf_size)
 
 	*protocol = hdr.arg;
 	IO_CHECK(fio_read_all(fio_stdin, payload_buf, hdr.size), hdr.size);
+}
+
+pio_file_kind_e
+pio_statmode2file_kind(mode_t mode, const char* path)
+{
+	pio_file_kind_e	kind;
+	if (S_ISREG(mode))
+		kind = PIO_KIND_REGULAR;
+	else if (S_ISDIR(mode))
+		kind = PIO_KIND_DIRECTORY;
+#ifdef S_ISLNK
+	else if (S_ISLNK(mode))
+		kind = PIO_KIND_SYMLINK;
+#endif
+#ifdef S_ISFIFO
+	else if (S_ISFIFO(mode))
+		kind = PIO_KIND_FIFO;
+#endif
+#ifdef S_ISSOCK
+	else if (S_ISFIFO(mode))
+		kind = PIO_KIND_SOCK;
+#endif
+#ifdef S_ISCHR
+	else if (S_ISCHR(mode))
+		kind = PIO_KIND_CHARDEV;
+#endif
+#ifdef S_ISBLK
+	else if (S_ISBLK(mode))
+		kind = PIO_KIND_BLOCKDEV;
+#endif
+	else
+		elog(ERROR, "Unsupported file mode kind \"%x\" for file '%s'",
+			 mode, path);
+	return kind;
+}
+
+pio_file_kind_e
+pio_str2file_kind(const char* str, const char* path)
+{
+	pio_file_kind_e	kind;
+	if (strncmp(str, "reg", 3) == 0)
+		kind = PIO_KIND_REGULAR;
+	else if (strncmp(str, "dir", 3) == 0)
+		kind = PIO_KIND_DIRECTORY;
+	else if (strncmp(str, "sym", 3) == 0)
+		kind = PIO_KIND_SYMLINK;
+	else if (strncmp(str, "fifo", 4) == 0)
+		kind = PIO_KIND_FIFO;
+	else if (strncmp(str, "sock", 4) == 0)
+		kind = PIO_KIND_SOCK;
+	else if (strncmp(str, "chdev", 5) == 0)
+		kind = PIO_KIND_CHARDEV;
+	else if (strncmp(str, "bldev", 5) == 0)
+		kind = PIO_KIND_BLOCKDEV;
+	else
+		elog(ERROR, "Unknown file kind \"%s\" for file '%s'",
+			 str, path);
+	return kind;
+}
+
+const char*
+pio_file_kind2str(pio_file_kind_e kind, const char *path)
+{
+	switch (kind)
+	{
+		case PIO_KIND_REGULAR:
+			return "reg";
+		case PIO_KIND_DIRECTORY:
+			return "dir";
+		case PIO_KIND_SYMLINK:
+			return "sym";
+		case PIO_KIND_FIFO:
+			return "fifo";
+		case PIO_KIND_SOCK:
+			return "sock";
+		case PIO_KIND_CHARDEV:
+			return "chdev";
+		case PIO_KIND_BLOCKDEV:
+			return "bldev";
+		default:
+			elog(ERROR, "Unknown file kind \"%d\" for file '%s'",
+				 kind, path);
+	}
+	return NULL;
+}
+
+#ifndef S_ISGID
+#define S_ISGID 0
+#endif
+#ifndef S_ISUID
+#define S_ISUID 0
+#endif
+#ifndef S_ISVTX
+#define S_ISVTX 0
+#endif
+
+mode_t
+pio_limit_mode(mode_t mode)
+{
+	if (S_ISDIR(mode))
+		mode &= 0x1ff | S_ISGID | S_ISUID | S_ISVTX;
+	else
+		mode &= 0x1ff;
+	return mode;
 }
 
 /* Open input stream. Remote file is fetched to the in-memory buffer and then accessed through Linux fmemopen */
@@ -1092,66 +1197,6 @@ fio_read(int fd, void* buf, size_t size)
 	{
 		return read(fd, buf, size);
 	}
-}
-
-/* Get information about file */
-int
-fio_stat(fio_location location, const char* path, struct stat* st, bool follow_symlink)
-{
-	if (fio_is_remote(location))
-	{
-		fio_header hdr = {
-			.cop = FIO_STAT,
-			.handle = -1,
-			.size = strlen(path) + 1,
-			.arg = follow_symlink,
-		};
-
-		IO_CHECK(fio_write_all(fio_stdout, &hdr, sizeof(hdr)), sizeof(hdr));
-		IO_CHECK(fio_write_all(fio_stdout, path, hdr.size), hdr.size);
-
-		IO_CHECK(fio_read_all(fio_stdin, &hdr, sizeof(hdr)), sizeof(hdr));
-		Assert(hdr.cop == FIO_STAT);
-		IO_CHECK(fio_read_all(fio_stdin, st, sizeof(*st)), sizeof(*st));
-
-		if (hdr.arg != 0)
-		{
-			errno = hdr.arg;
-			return -1;
-		}
-		return 0;
-	}
-	else
-	{
-		return follow_symlink ? stat(path, st) : lstat(path,  st);
-	}
-}
-
-/*
- * Compare, that filename1 and filename2 is the same file
- * in windows compare only filenames
- */
-bool
-fio_is_same_file(fio_location location, const char* filename1, const char* filename2, bool follow_symlink)
-{
-#ifndef WIN32
-	struct stat	stat1, stat2;
-
-	if (fio_stat(location, filename1, &stat1, follow_symlink) < 0)
-		elog(ERROR, "Can't stat file \"%s\": %s", filename1, strerror(errno));
-
-	if (fio_stat(location, filename2, &stat2, follow_symlink) < 0)
-		elog(ERROR, "Can't stat file \"%s\": %s", filename2, strerror(errno));
-
-	return stat1.st_ino == stat2.st_ino && stat1.st_dev == stat2.st_dev;
-#else
-	char	*abs_name1 = make_absolute_path(filename1);
-	char	*abs_name2 = make_absolute_path(filename2);
-	bool	result = strcmp(abs_name1, abs_name2) == 0;
-	free(abs_name2);
-	free(abs_name1);
-	return result;
-#endif
 }
 
 /*
@@ -3263,6 +3308,7 @@ fio_list_dir_impl(int out, char* buf)
 		fio_pgFile  fio_file;
 		pgFile	   *file = (pgFile *) parray_get(file_files, i);
 
+		fio_file.kind = file->kind;
 		fio_file.mode = file->mode;
 		fio_file.size = file->size;
 		fio_file.mtime = file->mtime;
@@ -3552,10 +3598,16 @@ fio_communicate(int in, int out)
 	size_t buf_size = 128*1024;
 	char* buf = (char*)pgut_malloc(buf_size);
 	fio_header hdr;
-	struct stat st;
+	pioDrive_i drive;
+	pio_stat_t st;
 	int rc;
 	int tmp_fd;
 	pg_crc32 crc;
+	err_i err = $noerr();
+
+	FOBJ_FUNC_ARP();
+
+	drive = pioDriveForLocation(FIO_LOCAL_HOST);
 
 #ifdef WIN32
 	SYS_CHECK(setmode(in, _O_BINARY));
@@ -3564,6 +3616,7 @@ fio_communicate(int in, int out)
 
 	/* Main loop until end of processing all master commands */
 	while ((rc = fio_read_all(in, &hdr, sizeof hdr)) == sizeof(hdr)) {
+		FOBJ_LOOP_ARP();
 		if (hdr.size != 0) {
 			if (hdr.size > buf_size) {
 				/* Extend buffer on demand */
@@ -3656,10 +3709,16 @@ fio_communicate(int in, int out)
 			}
 		  case FIO_STAT: /* Get information about file with specified path */
 			hdr.size = sizeof(st);
-			rc = hdr.arg ? stat(buf, &st) : lstat(buf, &st);
-			hdr.arg = rc < 0 ? errno : 0;
+			st = $i(pioStat, drive, buf, .follow_symlink = hdr.arg != 0,
+					 .err = &err);
+			hdr.arg = $haserr(err) ? getErrno(err) : 0;
 			IO_CHECK(fio_write_all(out, &hdr, sizeof(hdr)), sizeof(hdr));
 			IO_CHECK(fio_write_all(out, &st, sizeof(st)), sizeof(st));
+			break;
+		  case FIO_FILES_ARE_SAME:
+			hdr.arg = (int)$i(pioFilesAreSame, drive, buf, buf+strlen(buf)+1);
+			hdr.size = 0;
+			IO_CHECK(fio_write_all(out, &hdr, sizeof(hdr)), sizeof(hdr));
 			break;
 		  case FIO_ACCESS: /* Check presence of file with specified name */
 			hdr.size = 0;
@@ -3903,7 +3962,7 @@ pioFile_fobjDispose(VSelf)
 static bool
 common_pioExists(fobj_t self, path_t path, err_i *err)
 {
-    struct stat buf;
+    pio_stat_t buf;
     fobj_reset_err(err);
 
     /* follow symlink ? */
@@ -3913,7 +3972,7 @@ common_pioExists(fobj_t self, path_t path, err_i *err)
         *err = $noerr();
         return false;
     }
-    if ($noerr(*err) && !S_ISREG(buf.st_mode))
+    if ($noerr(*err) && buf.pst_kind != PIO_KIND_REGULAR)
         *err = $err(SysErr, "File {path:q} is not regular", path(path));
     if ($haserr(*err)) {
         *err = $syserr(getErrno(*err), "Could not check file existance: {cause:$M}",
@@ -3947,17 +4006,52 @@ pioLocalDrive_pioOpen(VSelf, path_t path, int flags,
     return bind_pioFile(file);
 }
 
-static struct stat
+static pio_stat_t
 pioLocalDrive_pioStat(VSelf, path_t path, bool follow_symlink, err_i *err)
 {
     struct stat	st = {0};
+    pio_stat_t pst = {0};
     int	r;
     fobj_reset_err(err);
 
     r = follow_symlink ? stat(path, &st) : lstat(path, &st);
     if (r < 0)
         *err = $syserr(errno, "Cannot stat file {path:q}", path(path));
-    return st;
+	else
+	{
+		pst.pst_kind = pio_statmode2file_kind(st.st_mode, path);
+		pst.pst_mode = pio_limit_mode(st.st_mode);
+		pst.pst_size = st.st_size;
+		pst.pst_mtime = st.st_mtime;
+	}
+    return pst;
+}
+
+/*
+ * Compare, that filename1 and filename2 is the same file
+ * in windows compare only filenames
+ */
+static bool
+pioLocalDrive_pioFilesAreSame(VSelf, path_t file1, path_t file2)
+{
+#ifndef WIN32
+	struct stat	stat1, stat2;
+
+	if (stat(file1, &stat1) < 0)
+		elog(ERROR, "Can't stat file \"%s\": %s", file1, strerror(errno));
+
+	if (stat(file2, &stat2) < 0)
+		elog(ERROR, "Can't stat file \"%s\": %s", file1, strerror(errno));
+
+	return stat1.st_ino == stat2.st_ino && stat1.st_dev == stat2.st_dev;
+#else
+	char	*abs_name1 = make_absolute_path(file1);
+	char	*abs_name2 = make_absolute_path(file2);
+	bool	result = strcmp(abs_name1, abs_name2) == 0;
+	free(abs_name2);
+	free(abs_name1);
+	return result;
+#endif
 }
 
 #define pioLocalDrive_pioExists common_pioExists
@@ -4213,10 +4307,10 @@ pioRemoteDrive_pioOpen(VSelf, path_t path,
     return bind_pioFile(file);
 }
 
-static struct stat
+static pio_stat_t
 pioRemoteDrive_pioStat(VSelf, path_t path, bool follow_symlink, err_i *err)
 {
-    struct stat	st = {0};
+    pio_stat_t	st = {0};
     fio_header hdr = {
             .cop = FIO_STAT,
             .handle = -1,
@@ -4238,6 +4332,32 @@ pioRemoteDrive_pioStat(VSelf, path_t path, bool follow_symlink, err_i *err)
 					   path(path));
     }
     return st;
+}
+
+static bool
+pioRemoteDrive_pioFilesAreSame(VSelf, path_t file1, path_t file2)
+{
+	fio_header hdr = {
+			.cop = FIO_FILES_ARE_SAME,
+			.handle = -1,
+			.arg = 0,
+	};
+	char _buf[512];
+	ft_strbuf_t buf = ft_strbuf_init_stack(_buf, sizeof(_buf));
+	ft_strbuf_catc(&buf, file1);
+	ft_strbuf_cat1(&buf, '\x00');
+	ft_strbuf_catc(&buf, file2);
+	hdr.size = buf.len + 1;
+
+	IO_CHECK(fio_write_all(fio_stdout, &hdr, sizeof(hdr)), sizeof(hdr));
+	IO_CHECK(fio_write_all(fio_stdout, buf.ptr, buf.len+1), buf.len+1);
+
+	IO_CHECK(fio_read_all(fio_stdin, &hdr, sizeof(hdr)), sizeof(hdr));
+	ft_dbg_assert(hdr.cop == FIO_FILES_ARE_SAME);
+
+	ft_strbuf_free(&buf);
+
+	return hdr.arg == 1;
 }
 
 #define pioRemoteDrive_pioExists common_pioExists
@@ -4388,6 +4508,7 @@ pioRemoteDrive_pioListDir(VSelf, parray *files, const char *root, bool handle_ta
             /* receive metainformation */
             IO_CHECK(fio_read_all(fio_stdin, &fio_file, sizeof(fio_file)), sizeof(fio_file));
 
+            file->kind = fio_file.kind;
             file->mode = fio_file.mode;
             file->size = fio_file.size;
             file->mtime = fio_file.mtime;

--- a/src/utils/file.h
+++ b/src/utils/file.h
@@ -105,7 +105,7 @@ typedef enum pio_file_kind {
 } pio_file_kind_e;
 
 typedef struct pio_stat {
-	uint64_t		pst_size;
+	int64_t			pst_size;
 	int64_t	 		pst_mtime;
 	uint32_t 		pst_mode;
 	pio_file_kind_e pst_kind;


### PR DESCRIPTION
- don't use full `struct stat` since it differs between platforms
- store file kind separately from mode in pb specific way
- add pioFilesAreSame as replacement of fio_is_same_file since it needs st_ino and st_dev, therefore had to run on localdrive always.