### PR TITLE
[PBCKP-354] Pg15: continue reading if error "missing contrecord" is met.

### DIFF
--- a/src/parsexlog.c
+++ b/src/parsexlog.c
@@ -1443,7 +1443,14 @@ XLogThreadWorker(void *arg)
 			 * Usually SimpleXLogPageRead() does it by itself. But here we need
 			 * to do it manually to support threads.
 			 */
-			if (reader_data->need_switch && errormsg == NULL)
+			if (reader_data->need_switch && (
+					errormsg == NULL ||
+					/*
+					 * Pg15 now informs if "contrecord" is missing.
+					 * TODO: probably we should abort reading logs at this moment.
+					 * But we continue as we did with bug present in Pg < 15.
+					 */
+					strncmp(errormsg, "missing contrecord", 18) == 0))
 			{
 				if (SwitchThreadToNextWal(xlogreader, thread_arg))
 					continue;


### PR DESCRIPTION
Pg15 now reports if it didn't met expected contrecord. Absence of this message was long standing bug in previous postgres versions.

This situation could happen if WAL segment was rewritten after restart.

It causes "tests.validate.ValidateTest.test_validate_wal_unreal_values" to hang but (looks like) for other reason: test tries to read "in future".

Probably we should stop reading logs here. But since we always did continue here, lets continue as well.