### PR TITLE
Fix for issue #628 [setuptools]

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,5 +9,6 @@ git+https://github.com/postgrespro/testgres.git@archive-command-exec#egg=testgre
 allure-pytest
 deprecation
 pexpect
+setuptools
 pytest==7.4.3
 pytest-xdist


### PR DESCRIPTION
It is a fix for python tests execution error:

> ModuleNotFoundError: No module named 'distutils'

See issue #628 for details.