### PR TITLE
Fix validate issue if segment size greater than 4GB.

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -1132,7 +1132,7 @@ restore_data_file_internal(FILE *in, FILE *out, pgFile *file, uint32 backup_vers
 			cur_pos_in != headers[n_hdr].pos)
 		{
 			if (fseek(in, headers[n_hdr].pos, SEEK_SET) != 0)
-				elog(ERROR, "Cannot seek to offset %u of \"%s\": %s",
+				elog(ERROR, "Cannot seek to offset %lu of \"%s\": %s",
 					headers[n_hdr].pos, from_fullpath, strerror(errno));
 
 			cur_pos_in = headers[n_hdr].pos;
@@ -1695,7 +1695,7 @@ validate_file_pages(pgFile *file, const char *fullpath, XLogRecPtr stop_lsn,
 					elog(ERROR, "Cannot seek block %u of \"%s\": %s",
 						blknum, fullpath, strerror(errno));
 				else
-					elog(VERBOSE, "Seek to %u", headers[n_hdr].pos);
+					elog(VERBOSE, "Seek to %lu", headers[n_hdr].pos);
 
 				cur_pos_in = headers[n_hdr].pos;
 			}

--- a/src/pg_probackup.h
+++ b/src/pg_probackup.h
@@ -704,8 +704,8 @@ typedef struct BackupPageHeader
 typedef struct BackupPageHeader2
 {
 	XLogRecPtr  lsn;
-	int32	    block;			 /* block number */
-	int32       pos;             /* position in backup file */
+	BlockNumber	block;			 /* block number */
+	off_t       pos;             /* position in backup file */
 	uint16      checksum;
 } BackupPageHeader2;
 


### PR DESCRIPTION
If we use segsize>4GB, e.g.
`./configure --prefix=/store2/Workspace/bin/pg16 --enable-debug --with-segsize=5 CFLAGS=-O2`
the backup or restore will be failed in the validate step:
```
INFO: Database backup start
INFO: wait for pg_backup_start()
2024-10-17 09:08:02.750 CST [2271890] LOG:  checkpoint starting: immediate force wait
2024-10-17 09:08:02.805 CST [2271890] LOG:  checkpoint complete: wrote 4 buffers (0.0%); 0 WAL file(s) added, 0 removed, 21 recycled; write=0.001 s, sync=0.005 s, total=0.056 s; sync files=3, longest=0.003 s, average=0.002 s; distance=339967 kB, estimate=521292 kB; lsn=3/51000060, redo lsn=3/51000028
INFO: Wait for WAL segment /store2/Workspace/data/probackup/backups/pg16/SLH75E/database/pg_wal/000000010000000300000051 to be streamed
INFO: PGDATA size: 15GB
INFO: Current Start LSN: 3/51000028, TLI: 1
INFO: Start transferring data files
INFO: Data files are transferred, time elapsed: 19s
2024-10-17 09:08:22.381 CST [2271938] LOG:  restore point "pg_probackup, backup_id SLH75E" created at 3/51000178
2024-10-17 09:08:22.381 CST [2271938] STATEMENT:  SELECT pg_catalog.pg_create_restore_point($1)
INFO: wait for pg_stop_backup()
INFO: pg_stop backup() successfully executed
INFO: stop_lsn: 3/510001A0
INFO: Getting the Recovery Time from WAL
INFO: Syncing backup files to disk
INFO: Backup files are synced, time elapsed: 4s
INFO: Validating backup SLH75E
ERROR: Cannot seek block 261889 of "/store2/Workspace/data/probackup/backups/pg16/SLH75E/database/base/5/24632": Invalid argument
ERROR: Data files validation failed
```
The reason is the block and pos parameter in struct BackupPageHeader2 declared as int32, and when datafile exceed 4G, the variables will overflow.

This patch fixed this  issue.